### PR TITLE
Drop `mips64le` and add `riscv64` platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,26 +60,22 @@ jobs:
         #   # - linux/arm/v6
         #   - linux/arm/v5
         #   - linux/386
-        #   - linux/mips64le
         #   - linux/ppc64le
+        #   - linux/riscv64
         #   - linux/s390x
         # exclude:
         #   - variant: fpm-alpine
         #     platform: linux/arm/v5
-        #   - variant: fpm-alpine
-        #     platform: linux/mips64le
         # include:
         #   - variant: fpm-alpine
         #     platform: linux/arm/v6
-        #   # - variant: fpm-alpine
-        #   #   platform: linux/riscv64
         include:
           - variant: apache
-            platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5,linux/386,linux/mips64le,linux/ppc64le,linux/s390x
+            platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5,linux/386,linux/ppc64le,linux/riscv64,linux/s390x
           - variant: fpm
-            platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5,linux/386,linux/mips64le,linux/ppc64le,linux/s390x
+            platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v5,linux/386,linux/ppc64le,linux/riscv64,linux/s390x
           - variant: fpm-alpine
-            platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386,linux/ppc64le,linux/s390x
+            platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386,linux/ppc64le,linux/riscv64,linux/s390x
     steps:
       - name: Retrieve context files
         uses: actions/download-artifact@v5


### PR DESCRIPTION
Ref https://github.com/docker-library/official-images/blob/72fd9bb936581a0657400b2271b2c7ab99e2c54b/library/php
See https://github.com/docker-library/official-images/pull/19660#issuecomment-3198610715